### PR TITLE
Fixes some bugs

### DIFF
--- a/commands.bat
+++ b/commands.bat
@@ -1,8 +1,12 @@
+if not exist "./tournamentBots" mkdir "./tournamentBots"
+
 IF "%1"=="" (
 	SET /p zip="Path to Agent ZIP: " 
 ) ELSE ( 
 	SET zip=%1
 )
+
+if not exist %zip% exit /B 404
 
 call :sub %zip%
 
@@ -10,7 +14,7 @@ START "" /wait cmd /c "copy %zip% .\src\main\resources\Bot.zip"
 START "" /wait cmd /c "mvn clean package -Dfilename=Bot"
 START "" /wait cmd /c "robocopy /e Template Bot"
 START "" /wait cmd /c "copy .\target\starcraftgoalaiwrapper-0.0.1-SNAPSHOT-shaded.jar .\Bot\AI"
-START "" /wait cmd /c "jar -cMf tournament%name%.zip -C Bot ."
+START "" /wait cmd /c "jar -cMf .\tournamentBots\%name%.zip -C Bot ."
 
 ::remove
 START "" /wait cmd /c "rd target /S /Q"
@@ -19,4 +23,5 @@ START "" /wait cmd /c "del src\main\resources\Bot.zip /Q"
 
 :sub
 SET name=%~n1
+SET name=%name:~0,24%
 exit /b


### PR DESCRIPTION
- No longer runs if the zip is not found.
- Makes tournamentBots folder if it doesn't exist. 
- Adds the tournament version of the bot to that folder.
- Removes the -now obsolete- prefix "tournament".
- Sets max filename length to 24 characters
